### PR TITLE
feat: add database target for du subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   enter <pod>               exec into pod
   sql <pod>                 launch mariadb shell
   proc <pod>                print processlist
-  du <pod>                  calculate database disk usage
+  du <pod> [-db <database>] calculate database disk usage
   top [<pod>]               display cpu and ram usage
   repl <replica>            check replication status
   skip <replica>            skip erroneous transactions
@@ -83,6 +83,7 @@ Flags:
   -k, --kubeconfig <file>   set kubeconfig path
   -n, --namespace <ns>      set namespace scope
   -y, --yes                 skip confirmation
+  -db, --database <db>      specify database for `du` subcommand
 
 Recreate Flags:
   -f, --force               ignore primary index mismatch

--- a/kubectl-mdba
+++ b/kubectl-mdba
@@ -257,6 +257,13 @@ parse_input() {
           err "option $1 requires an argument"
         fi
         ;;
+      -db|--database)
+        if [[ -n "$2" ]] && [[ "${2:0:1}" != "-" ]]; then
+          DATABASE="$2"; shift 2
+        else
+          err "option $1 requires an argument"
+        fi
+        ;;
       -y|--yes)
         KMDBA_SKIP_CONFIRMATION=1; shift
         ;;
@@ -523,7 +530,7 @@ mdba_sql() {
   exec_pod_it "${pod}" bash -c "mariadb --skip-ssl --user=root --password=\${MARIADB_ROOT_PASSWORD}"
 }
 
-#### proc <pod> - print processlist
+#### du <pod> [<database>] - calculate database disk usage
 # arg: none
 mdba_proc() {
   local pod
@@ -542,7 +549,11 @@ mdba_du() {
   pod="${KMDBA_TARGET}"
 
   get_pod "${pod}"
-  exec_pod "${pod}" bash -o pipefail -c "find /var/lib/mysql/ -maxdepth 1 -type d ! -name 'lost+found' -exec du --summarize --human-readable {} \; | sort --reverse --human-numeric-sort | awk --field-separator=/ '{print \$1, \$5}'"
+  if [[ -n "${DATABASE}" ]]; then
+    exec_pod "${pod}" bash -o pipefail -c "du --human-readable /var/lib/mysql/${DATABASE}/* 2>/dev/null | sort --reverse --human-numeric-sort || echo /var/lib/mysql/${DATABASE} - not found"
+  else
+    exec_pod "${pod}" bash -o pipefail -c "find /var/lib/mysql/ -maxdepth 1 -type d ! -name 'lost+found' -exec du --summarize --human-readable {} \; | sort --reverse --human-numeric-sort | awk --field-separator=/ '{print \$1, \$5}'"
+  fi
 }
 
 #### top [<pod>] - display cpu and ram usage

--- a/kubectl-mdba
+++ b/kubectl-mdba
@@ -6,7 +6,7 @@
 [[ -n "${DEBUG}" ]] && set -x
 set -eo pipefail
 
-VERSION="0.0.15"
+VERSION="0.0.16"
 OPERATOR_VERSION="26.3.0"
 
 KMDBA_KUBECTL="${KMDBA_KUBECTL:-kubectl}"
@@ -530,7 +530,7 @@ mdba_sql() {
   exec_pod_it "${pod}" bash -c "mariadb --skip-ssl --user=root --password=\${MARIADB_ROOT_PASSWORD}"
 }
 
-#### du <pod> [<database>] - calculate database disk usage
+#### proc <pod> - print processlist
 # arg: none
 mdba_proc() {
   local pod
@@ -541,7 +541,7 @@ mdba_proc() {
   run_sql_query "${pod}" 'SHOW PROCESSLIST;'
 }
 
-#### du <pod> - calculate database disk usage
+#### du <pod> [<database>] - calculate database disk usage
 # arg: none
 mdba_du() {
   local pod


### PR DESCRIPTION
This commit features new extensible functionality for `du` subcommand. It introduces `-db/--database <database>` option (that sets `${DATABASE}` variable) to inspect table disk space of an individual database. 

Here is how it looks:
```bash
./kubectl-mdba du mariadb-cluster-1-db-0 --database wp_123456 -n database | head -4
9.1M    /var/lib/mysql/wp_123456/wp_options.ibd
644K    /var/lib/mysql/wp_123456/wp_trp_gettext_en_us.ibd
468K    /var/lib/mysql/wp_123456/wp_trp_gettext_original_strings.ibd
452K    /var/lib/mysql/wp_123456/wp_postmeta.ibd
```

Potentially, `${DATABASE}` variable can be used for other subcommands in future, for example, in `proc`.